### PR TITLE
fix: return actual server-reported port

### DIFF
--- a/src/safe-listening-server.ts
+++ b/src/safe-listening-server.ts
@@ -22,7 +22,9 @@ export async function safeListeningHttpServer(
   do {
     try {
       const httpServer = await createListeningHttpServer(port, requestListener);
-      return { httpServer, port };
+      const address = httpServer.address();
+      const actualPort = typeof address === "object" && address !== null ? address.port : port;
+      return { httpServer, port: actualPort };
     } catch (e) {
       if (!isUsedPortError(e)) {
         throw e;


### PR DESCRIPTION
rather than assuming the one we've tried is the one used. more resilient against external changes in behavior.